### PR TITLE
FIX issue #74 - Replace URI.encode deprecated on ruby 2.7

### DIFF
--- a/lib/via_cep/http.rb
+++ b/lib/via_cep/http.rb
@@ -8,14 +8,18 @@ module ViaCep
     # return [Net::HTTPOK] | [Net::HTTPBadRequest]
     #
     def self.get(path:, query: {})
-      uri = URI(BASE_URL)
-      uri.path = "/ws/#{URI.encode(path)}/json"
-      uri.query = URI.encode_www_form(query)
-      Net::HTTP.get_response(uri)
+      Net::HTTP.get_response(ViaCep::HTTP.uri(path: path, query: query))
     end
 
     def self.was_successful?(request)
       request.code.eql?('200')
+    end
+
+    def self.uri(path:, query: {})
+      base_uri = URI(BASE_URL)
+      base_uri.path = "/ws/#{URI::Parser.new.escape(path)}/json"
+      base_uri.query = URI.encode_www_form(query)
+      base_uri
     end
   end
 end

--- a/spec/via_cep/http_spec.rb
+++ b/spec/via_cep/http_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ViaCep::HTTP do
+  context 'mount URI' do
+    it 'to address search' do
+      expect(ViaCep::HTTP.uri(path: 'SP/São Paulo/Fake address').path).to eq('/ws/SP/S%C3%A3o%20Paulo/Fake%20address/json')
+    end
+  end
+end


### PR DESCRIPTION
# Overview

## Implementation Details
Use `URI::Parser` instead of `URI.encode` on http GET

## Required Documentation Updates
New test created to ensure that the behavior is the same as when using `URI.encode`

## Testing Notes
None.

## API Changes
None.

## External Dependency Changes
None.